### PR TITLE
Fix lambda runtime

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ service: http-api-node-auth-simple
 
 provider:
   name: aws
-  runtime: node12.x
+  runtime: nodejs12.x
   httpApi:
     authorizers:
       serviceAuthorizer:


### PR DESCRIPTION
  An error occurred: GetProfileInfoLambdaFunction - Value node12.x at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: [java8, java11, nodejs10.x, nodejs12.x, python2.7, python3.6, python3.7, python3.8, dotnetcore2.1, go1.x, ruby2.5] or be a valid ARN (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException